### PR TITLE
Translate comments to English

### DIFF
--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -3,12 +3,12 @@
 """
 dependency_checker.py
 
-Ein Script, das aus LaTeX-Aux- und .tex-Dateien
-- einen Abhängigkeits-DAG zwischen Umgebungen (Lemmas, Definitionen, Theoreme etc.) erstellt,
-- die aktuelle Nummerierung gegen diesen DAG prüft,
-- und bei Bedarf eine topologische Neuordnung vorschlägt.
+A script that reads LaTeX .aux and .tex files and
+- creates a dependency DAG between environments (lemmas, definitions, theorems, etc.),
+- checks the current numbering against this DAG,
+- and, when necessary, suggests a topological reordering.
 
-Zusätzliche Kommentare helfen dir, jeden Schritt nachzuvollziehen.
+Additional comments help you follow each step.
 """
 
 import re
@@ -19,18 +19,18 @@ import sys
 
 def parse_aux(aux_path):
     r"""
-    Liest die .aux-Datei ein und extrahiert alle \newlabel-Definitionen.
-    \newlabel{<label>}{{<nummer>}{...}}
+    Read the .aux file and extract all \newlabel definitions.
+    \newlabel{<label>}{{<number>}{...}}
 
-    Rückgabe:
-      label_to_num: dict, mapping von label-Namen (str) zu Tupeln aus ints,
-                    z.B. "lem:foo" -> (1, 5)
+    Returns:
+      label_to_num: dict mapping label names (str) to tuples of ints,
+                    e.g. "lem:foo" -> (1, 5)
     """
     label_to_num = {}
     # Regex: \newlabel{LABEL}{{NUMBERS}{...}}
     pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([\d\.]+)\}")
 
-    # Zeile für Zeile einlesen
+    # Read the file line by line
     try:
         with open(aux_path, encoding='utf-8') as f:
             for line in f:
@@ -39,10 +39,10 @@ def parse_aux(aux_path):
                     continue
                 label = match.group(1)
                 num_str = match.group(2)
-                # Splitte "1.5.2" -> ["1","5","2"], wandle in ints
+                # Split "1.5.2" -> ["1","5","2"] and convert to ints
                 nums = tuple(int(n) for n in num_str.split('.'))
                 label_to_num[label] = nums
-                # Debug: print(f"Gefundenes Label: {label} -> Nummer {nums}")
+                # Debug: print(f"Found label: {label} -> number {nums}")
     except OSError as exc:
         print(f"Error reading {aux_path}: {exc}", file=sys.stderr)
         return {}
@@ -52,19 +52,18 @@ def parse_aux(aux_path):
 
 def parse_refs(tex_paths, ref_cmds):
     r"""
-    Durchsucht alle .tex-Dateien nach:
-     1) \label{...}-Befehlen => Position im Text + Label-Name
-     2) Referenz-Makros (z.B. \reflem{...}) => Position im Text + Ziel-Label
+    Search all .tex files for:
+     1) \label{...} commands => position in the text + label name
+     2) reference macros (e.g. \reflem{...}) => position in the text + target label
 
-    Aus der räumlichen Reihenfolge (Position im Dokument) wird ermittelt,
-    welches Label am nächsten vor einer Referenz steht.
+    From the document order (position) determine which label appears closest before a reference.
 
-    Rückgabe:
+    Returns:
       edges: List[Tuple[src_label, target_label]]
     """
     edges = []
 
-    # Label-Regex: findet alle \label{...}
+    # Label regex: finds all \label{...}
     label_pattern = re.compile(r"\\label\{([^}]+)\}")
 
     for tex_path in tex_paths:
@@ -75,46 +74,46 @@ def parse_refs(tex_paths, ref_cmds):
             print(f"Could not read {tex_path}: {exc}", file=sys.stderr)
             continue
 
-        # 1) Alle Labels mit ihrer Position sammeln
-        #    .start() liefert den Index im String, wir speichern (position, label_name)
+        # 1) Collect all labels with their position
+        #    .start() gives the index in the string; we store (position, label_name)
         labels = [(m.start(), m.group(1)) for m in label_pattern.finditer(content)]
-        # Explizit nach Position sortieren (nicht lexikographisch!)
+        # Sort explicitly by position (not lexicographically!)
         labels.sort(key=lambda x: x[0])
-        # Jetzt sind die Labels in der Reihenfolge, wie sie im Text erscheinen.
+        # Labels are now ordered as they appear in the text.
 
-        # 2) Alle Referenzen sammeln
-        refs = []  # Liste von (position, target_label)
+        # 2) Collect all references
+        refs = []  # list of (position, target_label)
         for cmd in ref_cmds:
-            # Baue Regex für jedes Makro: z.B. r"\\reflem\{([^}]+)\}" findet \reflem{foo}
+            # Build a regex for each macro: e.g. r"\\reflem\{([^}]+)\}" matches \reflem{foo}
             pat = re.compile(re.escape(cmd) + r"\{([^}]+)\}")
             for m in pat.finditer(content):
                 refs.append((m.start(), m.group(1)))
-        # Auch hier sortieren nach Position
+        # Sort by position here as well
         refs.sort(key=lambda x: x[0])
 
-        # 3) Für jede Referenz (pos, target) finde das letzte Label davor
+        # 3) For each reference (pos, target) find the last label before it
         for ref_pos, target_label in refs:
-            # Suche das Label mit der größten Position < ref_pos
+            # Look for the label with the greatest position < ref_pos
             src_label = None
             for label_pos, label_name in labels:
                 if label_pos < ref_pos:
                     src_label = label_name
                 else:
-                    # Sobald wir ein Label finden, das nach der Referenz kommt, beenden
+                    # Once we find a label that comes after the reference, stop
                     break
             if src_label:
                 edges.append((src_label, target_label))
-                # Debug: print(f"Kante: {src_label} -> {target_label}")
+                # Debug: print(f"Edge: {src_label} -> {target_label}")
 
     return edges
 
 
 def check_violations(edges, label_to_num):
     """
-    Prüft für jede Kante (src -> trg), ob die Nummer von trg < Nummer von src.
-    Ist dies nicht der Fall, so liegt eine Verletzung der DAG-Reihenfolge vor.
+    For each edge (src -> trg) check whether the number of ``trg`` is less than the number of ``src``.
+    If this is not the case, the DAG order is violated.
 
-    Rückgabe:
+    Returns:
       violations: List[Tuple[src, trg, num(src), num(trg)]]
     """
     violations = []
@@ -122,7 +121,7 @@ def check_violations(edges, label_to_num):
         if src in label_to_num and trg in label_to_num:
             num_src = label_to_num[src]
             num_trg = label_to_num[trg]
-            # Vergleich der Tupel (z.B. (1,6) > (1,5) bedeutet Verletzung)
+            # Compare tuples (e.g. (1,6) > (1,5) means a violation)
             if num_trg > num_src:
                 violations.append((src, trg, num_src, num_trg))
     return violations
@@ -130,30 +129,30 @@ def check_violations(edges, label_to_num):
 
 def suggest_reordering(edges, label_to_num):
     """
-    Baut aus allen Labels und Kanten einen Netzwerkx-DiGraph.
-    Prüft auf Zyklen:
-      - Falls Zyklen -> keine Toposort möglich -> None zurückgeben
-      - Falls kein Zyklus -> gebe Liste in topologischer Reihenfolge zurück
+    Build a NetworkX DiGraph from all labels and edges.
+    Check for cycles:
+      - If cycles exist -> no topological sort possible -> return None
+      - If there is no cycle -> return a list in topological order
 
-    Diese Reihenfolge ist eine mögliche Neu-Nummerierung, die alle Abhängigkeiten respektiert.
+    This order is a possible renumbering that respects all dependencies.
     """
     G = nx.DiGraph()
-    # Füge alle Labels als Knoten hinzu
+    # Add all labels as nodes
     G.add_nodes_from(label_to_num.keys())
-    # Füge alle Kanten (src -> trg) hinzu
+    # Add all edges (src -> trg)
     G.add_edges_from(edges)
 
-    # Zyklus-Check
+    # Cycle check
     if not nx.is_directed_acyclic_graph(G):
         return None
 
-    # Topologische Sortierung
+    # Topological sorting
     topo_order = list(nx.topological_sort(G))
     return topo_order
 
 
 def main():
-    # CLI-Parser einrichten
+    # Set up the CLI parser
     parser = argparse.ArgumentParser(
         description="Prüfe Abhängigkeiten zwischen Lemmas/Theoremen und deren Nummerierung."
     )
@@ -169,13 +168,13 @@ def main():
     )
     args = parser.parse_args()
 
-    # Schritt 1: Aux-Datei parsen -> Labelnummern ermitteln
+    # Step 1: parse aux file -> determine label numbers
     label_to_num = parse_aux(args.aux)
 
-    # Schritt 2: Tex-Dateien parsen -> Kantenliste erzeugen
+    # Step 2: parse tex files -> build edge list
     edges = parse_refs(args.tex, args.refs)
 
-    # Schritt 3: Verletzungen prüfen
+    # Step 3: check for violations
     violations = check_violations(edges, label_to_num)
     if violations:
         print("⚠️ Verletzungen der Reihenfolge gefunden:")
@@ -187,7 +186,7 @@ def main():
     else:
         print("✅ Keine Verletzungen: Die Nummerierung respektiert den Abhängigkeits-DAG.")
 
-    # Schritt 4: Vorschlag für Neuordnung
+    # Step 4: suggest a reordering
     topo = suggest_reordering(edges, label_to_num)
     if topo is None:
         print("❌ Der Graph enthält Zyklen, eine topologische Sortierung ist nicht möglich.")


### PR DESCRIPTION
## Summary
- translate all German comments and docstrings in `tex-reference-dag.py` into English
- keep code behavior unchanged

## Testing
- `python3 -m py_compile tex-reference-dag.py`


------
https://chatgpt.com/codex/tasks/task_e_6888be1786988331838c17b5ecdb8e72