### PR TITLE
Fix runtime type errors

### DIFF
--- a/draw_graphs.py
+++ b/draw_graphs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 # SPDX-License-Identifier: GPL-3.0-only
 # (c) 2025 Lino Joss Fidel Haupt
 #


### PR DESCRIPTION
## Summary
- fix `DiGraph` subscriptable type error by postponing annotations

## Testing
- `python -m py_compile draw_graphs.py tex-reference-dag.py`
- `python tex-reference-dag.py --help | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688a7660e2548331ba18030f32b06b9e