### PR TITLE
Improve graph drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ python tex-reference-dag.py main.aux *.tex
 
 If your `.tex` files reside in a different path than your `tex-reference-dag.py` just use absolute or relative paths.
 
+### 📈 Visualizing Dependencies
+
+To inspect the reference DAG you can generate TikZ graphs by passing
+`--draw-dir` together with `--draw-each-section` or
+`--draw-collapsed-sections`.
+Nodes that have no incoming or outgoing edges are omitted from these graphs
+to keep the drawings concise.
+
 ### 📝 Feedback and Contributions
 
 Feel free to open issues or submit pull requests for improvements or new features!

--- a/tex-reference-dag.1
+++ b/tex-reference-dag.1
@@ -48,6 +48,8 @@ Generate a TikZ graph for every section showing local dependencies.
 .TP
 .B --draw-collapsed-sections
 Generate a collapsed DAG where each node represents a section.
+Isolated nodes without edges are omitted from all generated graphs to keep
+the output concise.
 .SH ARGUMENTS
 .TP
 .I aux-file


### PR DESCRIPTION
## Summary
- ignore nodes without edges when drawing TikZ graphs
- mention that isolated nodes are omitted in the man page
- document the graph drawing options in the README

## Testing
- `python -m py_compile tex-reference-dag.py draw_graphs.py`
- `python tex-reference-dag.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688a9a4fca6483318a7e527087594a4e