### PR TITLE
Skip self edges & test for self references

### DIFF
--- a/tests/test_self_reference.py
+++ b/tests/test_self_reference.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import unittest
+import importlib.util
+
+# Load the main module directly from its file since it is not packaged
+MODULE_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "tex-reference-dag.py")
+spec = importlib.util.spec_from_file_location("texref", MODULE_PATH)
+texref = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(texref)
+parse_aux = texref.parse_aux
+parse_refs = texref.parse_refs
+suggest_reordering = texref.suggest_reordering
+
+
+class TestSelfReference(unittest.TestCase):
+    def test_self_reference_no_cycle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            aux_path = os.path.join(tmp, "doc.aux")
+            tex_path = os.path.join(tmp, "doc.tex")
+            with open(aux_path, "w", encoding="utf-8") as f:
+                f.write(r"\newlabel{lem:self}{{1}{1}}")
+            with open(tex_path, "w", encoding="utf-8") as f:
+                f.write(r"\label{lem:self} \reflem{lem:self}")
+
+            label_to_num = parse_aux(aux_path)
+            edges, future_edges = parse_refs(
+                [tex_path], ["\\reflem"], [], []
+            )
+
+            self.assertEqual(edges, [])
+            order = suggest_reordering(edges, label_to_num)
+            self.assertIsNotNone(order)
+            self.assertIn("lem:self", order)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -177,6 +177,9 @@ def parse_refs(
                     # Once we find a label that comes after the reference, stop
                     break
             if src_label and target_label.split(':', 1)[0] not in excluded_types:
+                # Skip self-references since they don't create ordering
+                if src_label == target_label:
+                    continue
                 if is_future:
                     future_edges.append((src_label, target_label))
                 else:


### PR DESCRIPTION
## Summary
- skip edges when a reference targets the same label
- test that self-referencing lemmas don't create a cycle

## Testing
- `python -m unittest discover -v -s tests`

------
https://chatgpt.com/codex/tasks/task_e_688aa1d120dc8331a873205f6c01fddb