### PR TITLE
Add layout option for TikZ export

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ To inspect the reference DAG you can generate TikZ graphs by passing
 `--draw-collapsed-sections`.
 Nodes that have no incoming or outgoing edges are omitted from these graphs
 to keep the drawings concise.
+The appearance of the graphs can be customised via `--layout` which accepts
+`dot`, `spring`, or `kamada_kawai` (the default).
 
 ### 📝 Feedback and Contributions
 

--- a/draw_graphs.py
+++ b/draw_graphs.py
@@ -110,6 +110,7 @@ def export_to_tikz(
     path: str,
     *,
     scale: float = 10.0,
+    layout: str = "kamada_kawai",
 ) -> None:
     """
     Draws the MultiDiGraph H in TikZ and uses name for the naming and path to save the file.
@@ -123,6 +124,9 @@ def export_to_tikz(
         scale:
             scaling factor passed to ``compute_coordinates`` to control
             node spacing in the output.
+        layout:
+            layout algorithm passed to ``compute_coordinates``. One of
+            ``'dot'``, ``'spring'`` or ``'kamada_kawai'``.
     OUTPUT:
         No output inside of python.
         However, the file in path will be written to.
@@ -136,7 +140,7 @@ def export_to_tikz(
 
     # Get the coordinates where the nodes shall be drawn.  We compute the layout
     # on the filtered graph ``G`` to ignore isolated nodes entirely.
-    pos = compute_coordinates(G, 'kamada_kawai', k=scale)
+    pos = compute_coordinates(G, layout, k=scale)
 
     with open(path, 'w', encoding='utf-8') as f:
         f.write("\\begin{tikzpicture}\n")

--- a/tex-reference-dag.1
+++ b/tex-reference-dag.1
@@ -50,6 +50,10 @@ Generate a TikZ graph for every section showing local dependencies.
 Generate a collapsed DAG where each node represents a section.
 Isolated nodes without edges are omitted from all generated graphs to keep
 the output concise.
+.TP
+.B --layout
+Layout algorithm for generated TikZ graphs. One of \fCdot\fR, \fCspring\fR, or
+\fCkamada_kawai\fR (default).
 .SH ARGUMENTS
 .TP
 .I aux-file

--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -242,6 +242,7 @@ def draw_section_graphs(
     *,
     draw_each_section: bool = True,
     draw_collapsed: bool = True,
+    layout: str = "kamada_kawai",
 ) -> None:
     """
     Draw graphs of the dependency structure.
@@ -252,6 +253,8 @@ def draw_section_graphs(
       - ``excluded_types``: label prefixes (like ``fig``) that are skipped.
       - ``draw_collapsed``: draw a DAG where each node represents a section.
       - ``draw_each_section``: draw a DAG for each individual section.
+      - ``layout``: layout algorithm for the generated TikZ graphs. One of
+        ``'dot'``, ``'spring'`` or ``'kamada_kawai'``.
     The resulting TikZ files are written into ``output_dir``.
     """
     # Prepare output directory
@@ -282,6 +285,7 @@ def draw_section_graphs(
             H_secs,
             name,
             os.path.join(output_dir, "collapsed_sections.tex"),
+            layout=layout,
         )
 
     if draw_each_section:
@@ -315,6 +319,7 @@ def draw_section_graphs(
                 sub_H,
                 name,
                 os.path.join(output_dir, filename),
+                layout=layout,
             )
 
 
@@ -341,6 +346,12 @@ def main() -> None:
         '--draw-collapsed-sections',
         action='store_true',
         help='Write a section-level DAG where nodes represent sections',
+    )
+    parser.add_argument(
+        '--layout',
+        choices=['dot', 'spring', 'kamada_kawai'],
+        default='kamada_kawai',
+        help='Layout algorithm for generated TikZ graphs',
     )
     args = parser.parse_args()
 
@@ -396,6 +407,7 @@ def main() -> None:
             args.draw_dir,
             draw_each_section=args.draw_each_section,
             draw_collapsed=args.draw_collapsed_sections,
+            layout=args.layout,
         )
 
 


### PR DESCRIPTION
## Summary
- allow choosing layout in `export_to_tikz`
- thread layout option through graph drawing helpers
- expose `--layout` CLI argument in `tex-reference-dag.py`
- document the new option in README and man page

## Testing
- `python -m py_compile draw_graphs.py tex-reference-dag.py`
- `python tex-reference-dag.py -h`

------
https://chatgpt.com/codex/tasks/task_e_688b32c96f048331bdf14c7aebe318c4