### PR TITLE
Add shell.nix with Python dependencies

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  packages = [
+    (pkgs.python3.withPackages (ps: with ps; [
+      networkx
+      pydot
+      pygraphviz
+      pytest
+    ]))
+    pkgs.graphviz
+  ];
+}
+


### PR DESCRIPTION
## Problem addressed
Missing explicit environment setup for running tests and tools reliably.

## Method of Mitigation
Provide a `shell.nix` that installs Python with required modules and Graphviz.

## Summary
- Added `shell.nix` defining a development shell with networkx, pydot, pygraphviz, pytest and graphviz.

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5b3901548331844f7e798e73908a