### PR TITLE
Add missing dependencies to Nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ This ensures your mathematical documents respect logical coherence, significantl
 Tex-Reference-DAG requires:
 
 * **Python 3.x**
-* **NetworkX** (`pip install networkx`)
+* **NetworkX**
+* **pydot**
+* **pygraphviz**
+* **numpy**
+* **scipy**
+* **Graphviz** (system package)
 
-No further external dependencies are required.
+All Python modules are available via `pip`. Alternatively, the provided
+`shell.nix` sets up a Nix development shell with everything preinstalled.
 
 ---
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  packages = [
+    (pkgs.python3.withPackages (ps: with ps; [
+      networkx
+      pydot
+      pygraphviz
+      pytest
+      numpy
+      scipy
+    ]))
+    pkgs.graphviz
+  ];
+} 
+


### PR DESCRIPTION
## Problem addressed
Nix shell was missing numerical libraries needed by the project and the README still claimed no further dependencies were required.

## Method of Mitigation
Extended `shell.nix` with numpy and scipy, and updated documentation accordingly.

## Summary
- `shell.nix` includes numpy and scipy alongside existing Python packages
- `README.md` lists the complete dependency set and points to `shell.nix`

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b5b3901548331844f7e798e73908a