### PR TITLE
Add environment-aware reference lookup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ Create a small JSON file describing all macros that introduce dependencies.
 It must contain a list `references` with ordinary references and may
 optionally list `future_references` for commands that deliberately point
 forward in the document as well as `excluded_types` for label prefixes
-that should be ignored:
+that should be ignored.  If your label prefixes do not match the names of
+the corresponding environments you can additionally provide an `env_map`
+mapping each prefix to the environment name used in the LaTeX source:
 
 ```json
 {
   "references": ["\\reflem", "\\refdef", "\\ref"],
   "future_references": ["\\fref"],
-  "excluded_types": ["fig", "eq"]
+  "excluded_types": ["fig", "eq"],
+  "env_map": {"def": ["defn"], "thm": ["thm"]}
 }
 ```
 

--- a/macros.example.json
+++ b/macros.example.json
@@ -4,6 +4,12 @@
   "references": ["\\reflem", "\\refdef", "\\refthm", "\\refcor", "\\ref"],
   "future_references": ["\\fref"],
   "excluded_types": ["fig", "eq"],
+  "env_map": {
+    "thm": ["thm"],
+    "lem": ["lem"],
+    "def": ["defn"],
+    "cor": ["cor"]
+  },
   "draw_dir": "graphs",
   "draw_each_section": false,
   "draw_collapsed_sections": false,

--- a/tests/test_environment_parsing.py
+++ b/tests/test_environment_parsing.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import tempfile
+import unittest
+import importlib.util
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "tex-reference-dag.py")
+sys.path.insert(0, os.path.dirname(MODULE_PATH))
+spec = importlib.util.spec_from_file_location("texref", MODULE_PATH)
+texref = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(texref)
+parse_refs = texref.parse_refs
+
+class TestEnvironmentParsing(unittest.TestCase):
+    def test_reference_inside_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tex_path = os.path.join(tmp, "doc.tex")
+            with open(tex_path, "w", encoding="utf-8") as f:
+                f.write(r"""
+\begin{thm}
+\label{thm:stuff}
+Foo
+\end{thm}
+\begin{proof}
+Use \reflem{lem:zorn}.
+\end{proof}
+
+A generalization of \refdef{def:category} yields
+\begin{defn}
+\label{def:twocat}
+See also \refthm{thm:stuff}.
+\end{defn}
+""")
+            edges, _ = parse_refs(
+                [tex_path],
+                ["\\reflem", "\\refdef", "\\refthm"],
+                [],
+                [],
+                {"thm": ["thm"], "def": ["defn"], "lem": ["lem"]},
+            )
+            self.assertIn(("def:twocat", "thm:stuff"), edges)
+            for e in edges:
+                self.assertNotEqual(e, ("thm:stuff", "def:category"))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_reference.py
+++ b/tests/test_self_reference.py
@@ -27,7 +27,7 @@ class TestSelfReference(unittest.TestCase):
 
             label_to_num = parse_aux(aux_path)
             edges, future_edges = parse_refs(
-                [tex_path], ["\\reflem"], [], []
+                [tex_path], ["\\reflem"], [], [], {"lem": ["lem"]}
             )
 
             self.assertEqual(edges, [])

--- a/tex-reference-dag.1
+++ b/tex-reference-dag.1
@@ -30,14 +30,18 @@ Labels should follow the form \fC\\label{<type>:<name>}\fR, e.g.
 \fC\\label{lem:zorn}\fR.  Entries with types \fCfig\fR and \fCeq\fR are
 ignored by default because their counters are independent of the section
 structure.  Additional types can be excluded via the macro configuration
-file.
+file.  The same file may define an \fCenv_map\fR object mapping label
+prefixes to the environments that contain them.  References are collected
+only inside the environment of each label, ensuring correct attribution.
 .SH OPTIONS
 .TP
 .B --config
 JSON file providing reference macros and default flag values. Command
-line options always override the values specified here. If omitted, the
-built-in defaults (\fC\\reflem \\refdef \\refthm \\refcor \\ref\fR with no
-future reference macros and excluding types \fCfig\fR and \fCeq\fR) are used.
+line options always override the values specified here.  It can also
+include an \fCenv_map\fR section mapping label prefixes to environment
+names. If omitted, the built-in defaults (\fC\\reflem \\refdef \\refthm
+\\refcor \\ref\fR with no future reference macros and excluding types
+\fCfig\fR and \fCeq\fR) are used.
 .TP
 .B --draw-dir
 Directory where TikZ graphs are written (default: \fCgraphs\fR).


### PR DESCRIPTION
## Summary
- extract `find_refs_for_label` helper to fetch references for a label from its environment
- refactor `parse_refs` to use this helper
- document `env_map` and new behaviour in the man page

## Testing
- `python -m unittest discover -v tests`


------
https://chatgpt.com/codex/tasks/task_e_688b7cb9fc608331b4dc10526a2fc240