### PR TITLE
Fix parsing of lettered numbers in aux file

### DIFF
--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -45,7 +45,10 @@ def parse_aux(aux_path: str) -> Dict[str, Tuple[int, ...]]:
     """
     label_to_num: Dict[str, Tuple[int, ...]] = {}
     # Regex to look for '\newlabel{LABEL}{{NUMBERS}'
-    pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([\d\.]+)\}")
+    # The number component may contain letters (e.g. 2a) or dots
+    # between numeric parts.  We capture everything up to the closing brace
+    # and later extract the leading digits of each part.
+    pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([^}]+)\}")
 
     # Read the file line by line
     try:
@@ -58,8 +61,14 @@ def parse_aux(aux_path: str) -> Dict[str, Tuple[int, ...]]:
                 label = match.group(1)
                 # get the NUMBERS part of the match with '\newlabel{LABEL}{{NUMBERS}'
                 num_str = match.group(2)
-                # Split "1.5.2" -> ["1","5","2"] and convert to ints
-                nums = tuple(int(n) for n in num_str.split('.'))
+                # Split "1.5a" -> ["1","5a"] and keep leading digits of each part
+                nums_list: List[int] = []
+                for part in num_str.split('.'):
+                    m = re.match(r"(\d+)", part)
+                    if m is None:
+                        break
+                    nums_list.append(int(m.group(1)))
+                nums = tuple(nums_list)
             # fill up the dictionary
                 label_to_num[label] = nums
                 # Debug: print(f"Found label: {label} -> number {nums}")


### PR DESCRIPTION
## Summary
- support aux entries with letters like `2a`

## Testing
- `pytest -q`
- manual run of `draw_section_graphs` with lettered labels


------
https://chatgpt.com/codex/tasks/task_e_688b9307f958833189e05369ec98d0fe