### PR TITLE
Fix lettered section numbers

### DIFF
--- a/tests/test_parse_aux_letters.py
+++ b/tests/test_parse_aux_letters.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import tempfile
+import unittest
+import importlib.util
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "tex-reference-dag.py")
+sys.path.insert(0, os.path.dirname(MODULE_PATH))
+spec = importlib.util.spec_from_file_location("texref", MODULE_PATH)
+texref = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(texref)
+parse_aux = texref.parse_aux
+
+
+class TestParseAuxLetters(unittest.TestCase):
+    def test_lettered_numbers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            aux_path = os.path.join(tmp, "doc.aux")
+            # The aux file contains label numbers with letters
+            with open(aux_path, "w", encoding="utf-8") as f:
+                f.write("\\newlabel{lem:first}{{1a}{1}}\n")
+                f.write("\\newlabel{lem:second}{{2.3b}{2}}\n")
+
+            label_to_num = parse_aux(aux_path)
+            # Only numeric prefixes should be parsed
+            self.assertEqual(label_to_num["lem:first"], (1,))
+            self.assertEqual(label_to_num["lem:second"], (2, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -45,7 +45,10 @@ def parse_aux(aux_path: str) -> Dict[str, Tuple[int, ...]]:
     """
     label_to_num: Dict[str, Tuple[int, ...]] = {}
     # Regex to look for '\newlabel{LABEL}{{NUMBERS}'
-    pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([\d\.]+)\}")
+    # The number component may contain letters like '2a' or '2.1b'.
+    # We capture everything up to the closing brace and later extract the
+    # leading digits of each part.
+    pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([^}]+)\}")
 
     # Read the file line by line
     try:
@@ -58,8 +61,16 @@ def parse_aux(aux_path: str) -> Dict[str, Tuple[int, ...]]:
                 label = match.group(1)
                 # get the NUMBERS part of the match with '\newlabel{LABEL}{{NUMBERS}'
                 num_str = match.group(2)
-                # Split "1.5.2" -> ["1","5","2"] and convert to ints
-                nums = tuple(int(n) for n in num_str.split('.'))
+                # Split "1.5a" -> ["1", "5a"] and keep only the numeric prefix
+                # of each part so labels like '2a' become (2,) and '2.3b'
+                # becomes (2, 3).
+                nums_list: List[int] = []
+                for part in num_str.split('.'):
+                    m = re.match(r"(\d+)", part)
+                    if m is None:
+                        break
+                    nums_list.append(int(m.group(1)))
+                nums = tuple(nums_list)
             # fill up the dictionary
                 label_to_num[label] = nums
                 # Debug: print(f"Found label: {label} -> number {nums}")


### PR DESCRIPTION
## Summary
- parse numbers with letters in `parse_aux`
- add regression test for lettered numbers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b9a1305d88331b6936c745641d39c