### PR TITLE
Draw graphs by connected components

### DIFF
--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -46,7 +46,9 @@ def parse_aux(aux_path: str) -> Dict[str, Tuple[int, ...]]:
     """
     label_to_num: Dict[str, Tuple[int, ...]] = {}
     # Regex to look for '\newlabel{LABEL}{{NUMBERS}'
-    pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([\d\.]+)\}")
+    pattern = re.compile(
+        r"\\newlabel\{([^}]+)\}\{\{([0-9]+(?:\.[0-9]+)*)(?:[a-zA-Z]*)\}"
+    )
 
     # Read the file line by line
     try:
@@ -367,6 +369,7 @@ def draw_section_graphs(
             name,
             os.path.join(output_dir, "collapsed_sections.tex"),
             layout=layout,
+            split_components=True,
         )
 
     if draw_each_section:
@@ -401,6 +404,7 @@ def draw_section_graphs(
                 name,
                 os.path.join(output_dir, filename),
                 layout=layout,
+                split_components=True,
             )
 
 


### PR DESCRIPTION
## Summary
- update `parse_aux` to ignore letters in numbers
- add `split_components` option to `export_to_tikz`
- export each weakly connected component separately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf8f64be8833188d9d78b0edec2b0