### PR TITLE
Add lemma tests with custom reference macros

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+./run_tests.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,9 @@ Use clear Markdown formatting for each section so the structure is easy to read.
 Always think twice before you do some potentially breaking changes and rather ask for my feedback than just doing something.
 Try to keep your intervals in which you work on your own short (<10min).
 If my task is too big, please break it down first and ask me for confirmation that you just do the first step.
+
+# Pre-commit Hook
+
+This repository uses a Git pre-commit hook located in `.githooks/pre-commit`.
+It runs `./run_tests.sh` before each commit. If the tests fail, the commit will
+be aborted. Review the test output to understand the failure before retrying.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python -m pytest -q

--- a/tests/test_full_document.py
+++ b/tests/test_full_document.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import tempfile
+import unittest
+import importlib.util
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "tex-reference-dag.py")
+sys.path.insert(0, os.path.dirname(MODULE_PATH))
+spec = importlib.util.spec_from_file_location("texref", MODULE_PATH)
+texref = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(texref)
+
+parse_aux = texref.parse_aux
+parse_refs = texref.parse_refs
+check_violations = texref.check_violations
+suggest_reordering = texref.suggest_reordering
+
+
+class TestFullDocument(unittest.TestCase):
+    def test_pipeline(self):
+        tex_path = os.path.join(os.path.dirname(__file__), "testlatex.tex")
+        with tempfile.TemporaryDirectory() as tmp:
+            aux_path = os.path.join(tmp, "doc.aux")
+            with open(aux_path, "w", encoding="utf-8") as f:
+                # numbers are deliberately ordered so prop:backcor > cor:back1
+                f.write("\\newlabel{def:1}{{1}{1}}\n")
+                f.write("\\newlabel{def:2}{{2}{1}}\n")
+                f.write("\\newlabel{def:3}{{3}{2}}\n")
+                f.write("\\newlabel{def:4}{{4}{2}}\n")
+                f.write("\\newlabel{lem:bar}{{5}{2}}\n")
+                f.write("\\newlabel{lem:foo}{{6}{2}}\n")
+                f.write("\\newlabel{thm:back3}{{7}{4}}\n")
+                f.write("\\newlabel{prop:backcor}{{8}{4}}\n")
+                f.write("\\newlabel{cor:back1}{{9}{3}}\n")
+            label_to_num = parse_aux(aux_path)
+            edges, future_edges = parse_refs(
+                [tex_path],
+                ["\\ref", "\\reflem"],
+                ["\\fref"],
+                [],
+                {
+                    "def": ["defn"],
+                    "thm": ["thm"],
+                    "prop": ["prop"],
+                    "cor": ["cor"],
+                    "lem": ["lem"],
+                },
+                ["lem", "thm", "prop", "cor"],
+            )
+
+            self.assertIn(("cor:back1", "def:1"), edges)
+            self.assertIn(("thm:back3", "def:3"), edges)
+            self.assertIn(("prop:backcor", "cor:back1"), edges)
+            self.assertIn(("lem:bar", "def:2"), edges)
+            self.assertIn(("lem:foo", "lem:bar"), edges)
+            self.assertIn(("def:2", "def:4"), future_edges)
+
+            violations = check_violations(edges, label_to_num)
+            self.assertEqual(violations, [("prop:backcor", "cor:back1", (8,), (9,))])
+
+            order = suggest_reordering(edges, label_to_num)
+            self.assertIsNotNone(order)
+            self.assertLess(order.index("prop:backcor"), order.index("cor:back1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testlatex.tex
+++ b/tests/testlatex.tex
@@ -17,6 +17,10 @@
 \newtheorem{rem}{Remark}[thm]
 \newtheorem{ex}{Example}[thm]
 
+% Simple wrappers for references used in tests
+\newcommand{\fref}[1]{\ref{#1}}
+\newcommand{\reflem}[1]{Lemma~\ref{#1}}
+
 \begin{document}
 
 \section{1}
@@ -27,8 +31,8 @@
 \end{defn}
 
 \begin{defn}
-	\label{def:2}
-	2
+        \label{def:2}
+        2, see \fref{def:4}
 \end{defn}
 
 \section{2}
@@ -39,9 +43,19 @@
 \end{defn}
 
 \begin{defn}
-	\label{def:4}
-	4
+        \label{def:4}
+        4
 \end{defn}
+
+\begin{lem}
+        \label{lem:bar}
+        Based on \ref{def:2}
+\end{lem}
+
+\begin{lem}
+        \label{lem:foo}
+        See \reflem{lem:bar}
+\end{lem}
 
 \section{3}
 

--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -46,7 +46,7 @@ def parse_aux(aux_path: str) -> Dict[str, Tuple[int, ...]]:
     """
     label_to_num: Dict[str, Tuple[int, ...]] = {}
     # Regex to look for '\newlabel{LABEL}{{NUMBERS}'
-    pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([\d\.]+)\}")
+    pattern = re.compile(r"\\newlabel\{([^}]+)\}\{\{([\d\.]+)[^}]*\}")
 
     # Read the file line by line
     try:


### PR DESCRIPTION
## Summary
- define \fref and \reflem in `tests/testlatex.tex`
- add two lemmas referencing each other via \reflem
- expand the full document test to parse these macros and check new edges
- add test runner script and pre-commit hook to ensure tests run before each commit

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_688bf899bacc8331820fb421891e765f