### PR TITLE
Add sec_name for compact section graph labels

### DIFF
--- a/draw_graphs.py
+++ b/draw_graphs.py
@@ -193,6 +193,16 @@ def name(t: Tuple[int, ...]) -> str:
     return "-".join(str(x) for x in t)
 
 
+def sec_name(t: Tuple[int, ...]) -> str:
+    """Return a dot-separated string skipping the first entry of ``t``.
+
+    This short form is used for graphs that depict the substructure of a single
+    section.  ``(3, 2, 5)`` becomes ``"2.5"``.
+    """
+
+    return ".".join(str(x) for x in t[1:])
+
+
 def rep_creator(level: int) -> Callable[[Tuple[int, ...]], Tuple[int, ...]]:
     """
     Erzeugt eine Funktion rep, die ein Tupel abschneidet auf die ersten `level` Einträge.

--- a/tex-reference-dag.py
+++ b/tex-reference-dag.py
@@ -32,7 +32,13 @@ import sys
 from typing import Dict, List, Optional, Tuple
 
 # import drawing utilities
-from draw_graphs import collapse_graph, export_to_tikz, rep_creator, name
+from draw_graphs import (
+    collapse_graph,
+    export_to_tikz,
+    rep_creator,
+    name,
+    sec_name,
+)
 
 
 def parse_aux(aux_path: str) -> Dict[str, Tuple[int, ...]]:
@@ -400,7 +406,7 @@ def draw_section_graphs(
             filename = f"section_{sec}.tex"
             export_to_tikz(
                 sub_H,
-                name,
+                sec_name,
                 os.path.join(output_dir, filename),
                 layout=layout,
                 split_components=True,


### PR DESCRIPTION
## Summary
- add `sec_name` in `draw_graphs.py` to trim the first element from tuples
- import and use `sec_name` when exporting per-section graphs

## Testing
- `bash ./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d371a71888331b93a530691f40969